### PR TITLE
Separated Hasher interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,13 @@ BUILDTOOL_IMAGE := buildtools:latest
 DOCKER_RUNNER   := docker run --rm -v $(CUR_DIR):$(SRCROOT) -w $(SRCROOT) -u `id -u`:`id -g`
 GO_CACHE        := $(BIN)/go-cache
 GO_BUILD_FLAGS  ?= -pkgdir $(SRCROOT)/$(GO_CACHE) -v -ldflags "-linkmode external -extldflags '-static' -s -w"
-GOBUILD         := $(DOCKER_RUNNER) -e CGO_ENABLED=1 -e GO111MODULE=off -e GOCACHE=$(SRCROOT)/$(GO_CACHE) $(BUILDTOOL_IMAGE) go build $(GO_BUILD_FLAGS)
 CCBUILD         := $(DOCKER_RUNNER) $(BUILDTOOL_IMAGE) gcc
 CMAKETOOL       := $(DOCKER_RUNNER) $(BUILDTOOL_IMAGE) cmake
 MAKETOOL        := $(DOCKER_RUNNER) $(BUILDTOOL_IMAGE) make
+BUILDER         := $(DOCKER_RUNNER) -e CGO_ENABLED=1 -e GO111MODULE=off -e GOCACHE=$(SRCROOT)/$(GO_CACHE) $(BUILDTOOL_IMAGE)
+GOBUILD         := $(BUILDER) go build $(GO_BUILD_FLAGS)
+GOTEST          := $(BUILDER) go test -v
+
 
 # helm chart path
 HELM_CHART_DB       := helm-charts/database-to-integrity-sum
@@ -74,10 +77,16 @@ generate:
 	@echo "==> Mocks have been generated"
 
 ## Runs the test suite with mocks enabled.
-.PHONY : test
-test: generate
-	go test -v ./internal/core/services/hash_test.go
-	go test -v ./pkg/hasher
+.PHONY: test
+test: generate test-bee2
+	@$(GOTEST) ./internal/core/services \
+	 	./pkg/hasher
+
+.PHONY: test-bee2
+test-bee2:
+ifeq ($(BEE2_ENABLED), true)
+	@$(GOTEST) -tags bee2 ./internal/ffi/bee2
+endif
 
 ## Downloads the necessesary dev dependencies.
 .PHONY : dev-dependencies

--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,7 @@ minikube:
 
 .PHONY: docker
 docker:
-	@eval $$(minikube docker-env) ;\
-	docker build -t $(FULL_IMAGE_NAME) -t $(IMAGE_NAME):latest -f ./docker/Dockerfile .
+	@docker build -t $(FULL_IMAGE_NAME) -t $(IMAGE_NAME):latest -f ./docker/Dockerfile .
 
 .PHONY : helm-all
 helm-all: helm-database helm-app

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ minikube:
 .PHONY: docker
 docker:
 	@eval $$(minikube docker-env) ;\
-	@docker build -t $(FULL_IMAGE_NAME) -t $(IMAGE_NAME):latest -f ./docker/Dockerfile .
+	docker build -t $(FULL_IMAGE_NAME) -t $(IMAGE_NAME):latest -f ./docker/Dockerfile .
 
 .PHONY : helm-all
 helm-all: helm-database helm-app

--- a/internal/ffi/bee2/bee2.go
+++ b/internal/ffi/bee2/bee2.go
@@ -30,7 +30,7 @@ var (
 )
 
 func NewDefault() hash.Hash {
-	// TODO: hid, hashSize from args
+	// TODO: take hid, hashSize from args
 	return New()
 }
 

--- a/internal/ffi/bee2/bee2.go
+++ b/internal/ffi/bee2/bee2.go
@@ -24,9 +24,13 @@ type bee2 struct {
 
 type Option func(*bee2)
 
-var _ hash.Hash = (*bee2)(nil)
+var (
+	_ hash.Hash         = (*bee2)(nil)
+	_ hasher.FileHasher = (*bee2)(nil)
+)
 
 func NewDefault() hash.Hash {
+	// TODO: hid, hashSize from args
 	return New()
 }
 
@@ -104,3 +108,8 @@ func (a *bee2) Size() int { return a.hashSize }
 
 // Hash interface.
 func (a *bee2) BlockSize() int { return BLOCKSIZE }
+
+// hasher.FileHasher interface
+func (a *bee2) HashFile(fileName string) (string, error) {
+	return Bee2HashFile(fileName)
+}

--- a/internal/ffi/bee2/bee2_test.go
+++ b/internal/ffi/bee2/bee2_test.go
@@ -14,26 +14,25 @@ import (
 	"github.com/ScienceSoft-Inc/integrity-sum/pkg/hasher"
 )
 
-const fname = "../../../go.sum"
+const testFileName = "../../../.editorconfig"
 
 var expectedValues = map[string]string{
 	// standart
-	"SHA256": "88370d2c5fc8452a05ad7382c8df5902a76f27639970d059ef44d1c66e3267f2",
+	"SHA256": "5a56cf93d0987654cd2cad1b6616e1f413b0984c59e56470f450176246e42e47",
 	// bee2 library
-	// "BEE2": "0c7bc5135b916cf99acee975062f751f", // hid:16
-	"BEE2": "8338f17aa18424e1ed3c1e3c5071149505af67ce164d6e81a15c023621fe2b02", // hid:32
+	"BEE2": "473c1b38fbd2f1e6480776370c56a317a4702e2742c28b27679cba013678529f",
 }
 
 func TestBee2Hasher(t *testing.T) {
 	log := logrus.New()
-	absName, err := filepath.Abs(fname)
+	absName, err := filepath.Abs(testFileName)
 	assert.NoError(t, err)
 
 	for algName, want := range expectedValues {
 		h := hasher.NewFileHasher(algName, log)
 		hash, err := h.HashFile(absName)
 		assert.NoError(t, err)
-		assert.Equal(t, want, hash)
+		assert.Equal(t, want, hash, "alg: %v", algName)
 	}
 
 	// bee2 with Go Hash interface

--- a/internal/ffi/bee2/bee2_test.go
+++ b/internal/ffi/bee2/bee2_test.go
@@ -16,7 +16,7 @@ import (
 
 const fname = "../../../go.sum"
 
-var testCases = map[string]string{
+var expectedValues = map[string]string{
 	// standart
 	"SHA256": "88370d2c5fc8452a05ad7382c8df5902a76f27639970d059ef44d1c66e3267f2",
 	// bee2 library
@@ -29,7 +29,7 @@ func TestBee2Hasher(t *testing.T) {
 	absName, err := filepath.Abs(fname)
 	assert.NoError(t, err)
 
-	for algName, want := range testCases {
+	for algName, want := range expectedValues {
 		h := hasher.NewFileHasher(algName, log)
 		hash, err := h.HashFile(absName)
 		assert.NoError(t, err)
@@ -46,5 +46,5 @@ func TestBee2Hasher(t *testing.T) {
 
 	hash, err := goHasher.HashData(bytes.NewReader(data))
 	assert.NoError(t, err)
-	assert.Equal(t, testCases["BEE2"], hash)
+	assert.Equal(t, expectedValues["BEE2"], hash)
 }

--- a/internal/ffi/bee2/bee2_test.go
+++ b/internal/ffi/bee2/bee2_test.go
@@ -1,0 +1,50 @@
+//go:build bee2
+
+package bee2
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ScienceSoft-Inc/integrity-sum/pkg/hasher"
+)
+
+const fname = "../../../go.sum"
+
+var testCases = map[string]string{
+	// standart
+	"SHA256": "88370d2c5fc8452a05ad7382c8df5902a76f27639970d059ef44d1c66e3267f2",
+	// bee2 library
+	// "BEE2": "0c7bc5135b916cf99acee975062f751f", // hid:16
+	"BEE2": "8338f17aa18424e1ed3c1e3c5071149505af67ce164d6e81a15c023621fe2b02", // hid:32
+}
+
+func TestBee2Hasher(t *testing.T) {
+	log := logrus.New()
+	absName, err := filepath.Abs(fname)
+	assert.NoError(t, err)
+
+	for algName, want := range testCases {
+		h := hasher.NewFileHasher(algName, log)
+		hash, err := h.HashFile(absName)
+		assert.NoError(t, err)
+		assert.Equal(t, want, hash)
+	}
+
+	// bee2 with Go Hash interface
+	data, err := os.ReadFile(absName)
+	assert.NoError(t, err)
+
+	h := hasher.NewFileHasher("BEE2", log)
+	goHasher, ok := h.(*hasher.Hasher)
+	assert.True(t, ok)
+
+	hash, err := goHasher.HashData(bytes.NewReader(data))
+	assert.NoError(t, err)
+	assert.Equal(t, testCases["BEE2"], hash)
+}

--- a/internal/ffi/bee2/wrapper.go
+++ b/internal/ffi/bee2/wrapper.go
@@ -75,10 +75,10 @@ import (
 const (
 	// The depth (or strench) of algorithm. The valid values are 32..512 with
 	// step 32.
-	HID int = 128
+	HID int = 256
 	// The default value for the algorithm is 64. But it may not use all the
 	// memory. Real usage depends on HID value and calculates as HID/8.
-	HASHSIZE = 16
+	HASHSIZE = 32
 	// Bytes, len of block for data processing
 	BLOCKSIZE = 4096
 )

--- a/pkg/hasher/hasher.go
+++ b/pkg/hasher/hasher.go
@@ -1,27 +1,70 @@
 package hasher
 
 import (
+	"bytes"
 	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
+	"encoding/hex"
 	"fmt"
 	"hash"
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
 )
 
+// Expands default Go Hash interface
+type FileHasher interface {
+	HashFile(fileName string) (string, error)
+}
+
+type Hasher struct {
+	h   hash.Hash
+	log *logrus.Logger
+}
+
 type InitFunc func() hash.Hash
+
+var algs = make(map[string]InitFunc)
 
 func init() {
 	// default algs
 	RegisterAlg("MD5", md5.New)
 	RegisterAlg("SHA1", sha1.New)
-	RegisterAlg("SHA224", sha256.New)
+	RegisterAlg("SHA224", sha256.New224)
 	RegisterAlg("SHA256", sha256.New)
-	RegisterAlg("SHA384", sha512.New)
+	RegisterAlg("SHA384", sha512.New384)
 	RegisterAlg("SHA512", sha512.New)
 }
 
-var algs = make(map[string]InitFunc)
+// HashFile calculates hash for file
+func (fh *Hasher) HashFile(fullFileName string) (string, error) {
+	if ownFileHasher, ok := fh.h.(FileHasher); ok {
+		return ownFileHasher.HashFile(fullFileName)
+	}
+
+	data, err := os.ReadFile(fullFileName)
+	if err != nil {
+		fh.log.WithError(err).Errorf("can not read from file %q", fullFileName)
+		return "", err
+	}
+	return fh.HashData(bytes.NewReader(data))
+}
+
+// HashData calculates hash for a data represented with @r.
+// Uses default Go Hash interface.
+func (fh *Hasher) HashData(r *bytes.Reader) (string, error) {
+	fh.h.Reset()
+	cntBytes, err := io.Copy(fh.h, r)
+	if err != nil {
+		fh.log.WithError(err).Error("io.Copy()")
+		return "", err
+	}
+	fh.log.WithField("cntBytes", cntBytes).Debug("io.Copy() written bytes")
+	return hex.EncodeToString(fh.h.Sum(nil)), nil
+}
 
 // Registers init func for @name hasher
 func RegisterAlg(name string, f InitFunc) bool {
@@ -39,4 +82,13 @@ func NewHashSum(algName string) hash.Hash {
 		return sha256.New()
 	}
 	return initFunc()
+	// TODO: log actual name of selected alg. Or return true/false signal
+}
+
+// Returns new FileHasher instance
+func NewFileHasher(algName string, log *logrus.Logger) FileHasher {
+	return &Hasher{
+		h:   NewHashSum(algName), // TODO: rename it and check that only workers call it
+		log: log,
+	}
 }

--- a/pkg/hasher/hasher.go
+++ b/pkg/hasher/hasher.go
@@ -73,9 +73,9 @@ func RegisterAlg(name string, f InitFunc) bool {
 	return true
 }
 
-// NewHashSum takes a hashing algorithm name as input and returns registered (or
-// default, if name is not defined) hasher for this algorithm.
-func NewHashSum(algName string) hash.Hash {
+// newHasherInstance takes a hashing algorithm name as input and returns
+// registered (or default, if name is not recognized) hasher for this algorithm.
+func newHasherInstance(algName string) hash.Hash {
 	initFunc, ok := algs[algName]
 	if !ok {
 		// returns default, sha256
@@ -88,7 +88,7 @@ func NewHashSum(algName string) hash.Hash {
 // Returns new FileHasher instance
 func NewFileHasher(algName string, log *logrus.Logger) FileHasher {
 	return &Hasher{
-		h:   NewHashSum(algName), // TODO: rename it and check that only workers call it
+		h:   newHasherInstance(algName),
 		log: log,
 	}
 }

--- a/pkg/hasher/hasher_test.go
+++ b/pkg/hasher/hasher_test.go
@@ -1,10 +1,6 @@
 package hasher
 
 import (
-	"encoding/hex"
-	"io"
-	"log"
-	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -13,19 +9,6 @@ import (
 
 const testFileName = "../../.editorconfig"
 
-// TODO: repeat test with the same hasher
-
-// before
-// var expectedValues = map[string]string{
-// 	"MD5":    "f670b69b3d123fa53e3e1848a0b6bf6b",
-// 	"SHA1":   "da39a3ee5e6b4b0d3255bfef95601890afd80709",
-// 	"SHA224": "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f",
-// 	"SHA384": "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
-// 	"SHA512": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
-// 	"SHA256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-// }
-
-// new
 var expectedValues = map[string]string{
 	// $ md5sum .editorconfig
 	// f670b69b3d123fa53e3e1848a0b6bf6b  .editorconfig
@@ -56,27 +39,15 @@ func TestHashAlgs(t *testing.T) {
 	}
 }
 
-func TestNewHashSum(t *testing.T) {
-	hashAlgos := []string{"MD5", "SHA1", "SHA224", "SHA384", "SHA512", "SHA256"}
-	file, err := os.OpenFile(testFileName, os.O_RDONLY, 0)
-	if err != nil {
-		log.Printf("Error reading file[%s]: %s", testFileName, err)
-		t.Fail()
-		return
-	}
-	for _, v := range hashAlgos {
-		// hashSummator := NewHashSum(v)
-		hashSummator := NewFileHasher(v, logrus.New()).(*Hasher).h
-
-		_, err = io.Copy(hashSummator, file)
-		if err != nil {
-			log.Printf("Error reading file[%s] with algorithm[%s]: %s", testFileName, v, err)
-		}
-		res := hex.EncodeToString(hashSummator.Sum(nil))
-		if res != expectedValues[v] {
-			log.Printf("New hash not corresponding to default value. %s(new hash) != %s(default value)", res, expectedValues[v])
-			t.Fail()
-			return
-		}
-	}
+func TestRepeated(t *testing.T) {
+	alg := "SHA256"
+	hasher := NewFileHasher(alg, logrus.New())
+	// 1
+	hash, err := hasher.HashFile(testFileName)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedValues[alg], hash, "alg: %s", alg)
+	// 2
+	hash, err = hasher.HashFile(testFileName)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedValues[alg], hash, "alg: %s", alg)
 }

--- a/pkg/hasher/hasher_test.go
+++ b/pkg/hasher/hasher_test.go
@@ -6,36 +6,75 @@ import (
 	"log"
 	"os"
 	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
-const fp = "../../.editorconfig"
+const testFileName = "../../.editorconfig"
 
-var defaultValues = map[string]string{
-	"MD5":    "f670b69b3d123fa53e3e1848a0b6bf6b",
-	"SHA1":   "da39a3ee5e6b4b0d3255bfef95601890afd80709",
-	"SHA224": "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f",
-	"SHA384": "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
-	"SHA512": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
-	"SHA256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+// TODO: repeat test with the same hasher
+
+// before
+// var expectedValues = map[string]string{
+// 	"MD5":    "f670b69b3d123fa53e3e1848a0b6bf6b",
+// 	"SHA1":   "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+// 	"SHA224": "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f",
+// 	"SHA384": "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
+// 	"SHA512": "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+// 	"SHA256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+// }
+
+// new
+var expectedValues = map[string]string{
+	// $ md5sum .editorconfig
+	// f670b69b3d123fa53e3e1848a0b6bf6b  .editorconfig
+	"MD5": "f670b69b3d123fa53e3e1848a0b6bf6b",
+
+	"SHA1": "40ed457cdd863b52153246992298e4c10b4c7833",
+
+	// $ sha224sum .editorconfig
+	// 91aab9267c12bf42be3ae87f15afcb1adc52e6301076f5094c843b78  .editorconfig
+	"SHA224": "91aab9267c12bf42be3ae87f15afcb1adc52e6301076f5094c843b78",
+
+	"SHA384": "80f04572e3078da6d775adc7de9cea8af9c141fd12bd232fc22c43bc27f67559c34d20b666514e7bdfa68cd11c2e45e7",
+
+	// $ sha512sum .editorconfig
+	// dda4a0dd082392a0447afe99dc67b4b39170dd84731986015b047e2e70237232a276e5899aaaca544103f34b61ddfbb91e0ed57b76afe80d2bf65e982a8e7724  .editorconfig
+	"SHA512": "dda4a0dd082392a0447afe99dc67b4b39170dd84731986015b047e2e70237232a276e5899aaaca544103f34b61ddfbb91e0ed57b76afe80d2bf65e982a8e7724",
+
+	// $ sha256sum .editorconfig
+	// 5a56cf93d0987654cd2cad1b6616e1f413b0984c59e56470f450176246e42e47  .editorconfig
+	"SHA256": "5a56cf93d0987654cd2cad1b6616e1f413b0984c59e56470f450176246e42e47",
+}
+
+func TestHashAlgs(t *testing.T) {
+	for alg := range expectedValues {
+		hash, err := NewFileHasher(alg, logrus.New()).HashFile(testFileName)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedValues[alg], hash, "alg: %s", alg)
+	}
 }
 
 func TestNewHashSum(t *testing.T) {
 	hashAlgos := []string{"MD5", "SHA1", "SHA224", "SHA384", "SHA512", "SHA256"}
-	file, err := os.OpenFile(fp, os.O_RDONLY, 0)
+	file, err := os.OpenFile(testFileName, os.O_RDONLY, 0)
 	if err != nil {
-		log.Printf("Error reading file[%s]: %s", fp, err)
+		log.Printf("Error reading file[%s]: %s", testFileName, err)
 		t.Fail()
 		return
 	}
 	for _, v := range hashAlgos {
-		hashSummator := NewHashSum(v)
+		// hashSummator := NewHashSum(v)
+		hashSummator := NewFileHasher(v, logrus.New()).(*Hasher).h
+
 		_, err = io.Copy(hashSummator, file)
 		if err != nil {
-			log.Printf("Error reading file[%s] with algorithm[%s]: %s", fp, v, err)
+			log.Printf("Error reading file[%s] with algorithm[%s]: %s", testFileName, v, err)
 		}
 		res := hex.EncodeToString(hashSummator.Sum(nil))
-		if res != defaultValues[v] {
-			log.Printf("New hash not corresponding to default value. %s(new hash) != %s(default value)", res, defaultValues[v])
+		if res != expectedValues[v] {
+			log.Printf("New hash not corresponding to default value. %s(new hash) != %s(default value)", res, expectedValues[v])
 			t.Fail()
 			return
 		}


### PR DESCRIPTION
Usage example:
```go
hash, err := NewFileHasher("MD5", logrus.New()).HashFile(fileName)
```