### PR TITLE
bug: fix init kubeData

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,4 +250,4 @@ ensure-export-dir:
 
 .PHONY: clear-snapshot
 clear-snapshot:
-	@-rm -rf $(DOCKER_FS_DIR)/* $(BIN)/snapshot.*.txt
+	@-rm -rf $(DOCKER_FS_DIR)/* $(SNAPSHOT_OUTPUT)

--- a/cmd/k8s-integrity-sum/main.go
+++ b/cmd/k8s-integrity-sum/main.go
@@ -49,6 +49,8 @@ func main() {
 		log.Fatalf("failed connect to database: %w", err)
 	}
 
+	k8s.InitKubeData()
+
 	// 	// Create alert sender
 	if viper.GetBool("splunk-enabled") {
 		splunkUrl := viper.GetString("splunk-url")

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -3,14 +3,16 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"github.com/ScienceSoft-Inc/integrity-sum/internal/logger"
+	"os"
+	"strings"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"os"
-	"strings"
+
+	"github.com/ScienceSoft-Inc/integrity-sum/internal/logger"
 )
 
 //go:generate mockgen -source=k8s.go -destination=mocks/mock_k8s.go
@@ -44,12 +46,8 @@ type KubeClient struct {
 
 var kubeData *KubeData
 
-func init() {
-	initKubeData()
-}
-
 // initKubeData initializes kubeData global variable
-func initKubeData() {
+func InitKubeData() {
 	log := logger.Init(viper.GetString("verbose"))
 	namespaceBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {


### PR DESCRIPTION
Why: 
Creating image snapshot depends on the `integritymonitor` package which includes `k8s` package. So we've got the `initKubeData()` call that can't be completed.

What: 
The `initKubeData()` call moved into the main function.
